### PR TITLE
Update to Python 3.10 (when released on miniconda)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - default
 dependencies:
-  - python>=3.9
+  - python=3.10
   - bokeh
   - cartopy==0.19.0
   - cython

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - default
 dependencies:
-  - python=3.9
+  - python>=3.9
   - bokeh
   - cartopy==0.19.0
   - cython


### PR DESCRIPTION
I think that this is causing us to use older versions of packages that ship with specific versions of Python, right? Maybe we should make the CI run on different versions of Python? Context: https://github.com/Toblerity/Fiona/issues/986