### PR TITLE
Add geometry creation examples

### DIFF
--- a/02-spatial-data.qmd
+++ b/02-spatial-data.qmd
@@ -70,13 +70,13 @@ else:
 ```
 
 ```{python}
-dat = gpd.read_file("data/world.gpkg")
+gdf = gpd.read_file("data/world.gpkg")
 ```
 
 The result is a `GeoDataFrame`:
 
 ```{python}
-type(dat)
+type(gdf)
 ```
 
 The `GeoDataFrame` class is an extension of the `DataFrame` class. 
@@ -84,42 +84,42 @@ Thus, we can treat a vector layer as a table and process it using the ordinary, 
 For example, the following expression creates a subset with just the country name and the geometry (see below):
 
 ```{python}
-dat = dat[["name_long", "geometry"]]
-dat
+gdf = gdf[["name_long", "geometry"]]
+gdf
 ```
 
 The following expression creates a subset based on a condition, including just `"Egypt"`:
 
 ```{python}
-dat[dat["name_long"] == "Egypt"]
+gdf[gdf["name_long"] == "Egypt"]
 ```
 
 Finally, to get a sense of the spatial component of the vector layer, it can be plotted using the `.plot` method, as follows:
 
 ```{python}
-dat.plot()
+gdf.plot()
 ```
 
 or using `.hvplot` to get an interactive plot:
 
 ```{python}
 # import hvplot.pandas
-# dat.hvplot(title='Hello world', geo=True, hover_cols=['name_long'], legend=False).opts(bgcolor='lightgray', active_tools=['wheel_zoom']) 
+# gdf.hvplot(title='Hello world', geo=True, hover_cols=['name_long'], legend=False).opts(bgcolor='lightgray', active_tools=['wheel_zoom']) 
 ```
 
 This way, we can also add background tiles:
 
 ```{python}
-# dat.hvplot(tiles='OSM', alpha=0.5, geo=True, title='Hello world', hover_cols=['name_long'], legend=False).opts(active_tools=['wheel_zoom']) 
+# gdf.hvplot(tiles='OSM', alpha=0.5, geo=True, title='Hello world', hover_cols=['name_long'], legend=False).opts(active_tools=['wheel_zoom']) 
 ```
 
 ### Geometry columns
 
 One of the columns in a `GeoDataFrame` is a geometry column, of class `GeoSeries`.
-The geometry column contains the geometric part of the vector layer, e.g., the `POLYGON` or `MULTIPOLYGON` geometries of the 177 countries in `dat`:
+The geometry column contains the geometric part of the vector layer, e.g., the `POLYGON` or `MULTIPOLYGON` geometries of the 177 countries in `gdf`:
 
 ```{python}
-dat["geometry"]
+gdf["geometry"]
 ```
 
 The geometry column also contains the spatial reference information, if any (see below).
@@ -128,11 +128,11 @@ Many of the spatial operators, such as calculating the centroid, buffer, or boun
 Therefore, for example, the following expressions give exactly the same result, a `GeoSeries` with country bounding boxes:
 
 ```{python}
-dat.bounds
+gdf.bounds
 ```
 
 ```{python}
-dat["geometry"].bounds
+gdf["geometry"].bounds
 ```
 
 Another useful property of the geometry column is the geometry type (see below). 
@@ -140,16 +140,16 @@ Note that the types of geometries contained in a geometry column (and, thus, a v
 Accordingly, the `.type` property returns a `Series` (of type `string`), rather than a single value:
 
 ```{python}
-dat["geometry"].type
+gdf["geometry"].type
 ```
 
 To summarize the occurrence of different geometry types in a geometry column, we can use the **pandas** method called `value_counts`:
 
 ```{python}
-dat["geometry"].type.value_counts()
+gdf["geometry"].type.value_counts()
 ```
 
-In this case, we see that the `dat` layer contains `Polygon` and `MultiPolygon` geometries.
+In this case, we see that the `gdf` layer contains `Polygon` and `MultiPolygon` geometries.
 
 ### Geometries
 
@@ -157,22 +157,29 @@ Each element in the geometry column is a geometry object, of class `shapely`.
 For example, here is one specific geometry selected by implicit index (that of Canada):
 
 ```{python}
-dat["geometry"].iloc[3]
+gdf["geometry"].iloc[3]
 ```
 
 and here is a specific geometry selected based on the `"name_long"` attribute:
 
 ```{python}
-dat[dat["name_long"] == "Egypt"]["geometry"].iloc[0]
+gdf[gdf["name_long"] == "Egypt"]["geometry"].iloc[0]
 ```
 
 The **shapely** package is compatible with the Simple Features standard.
 Accordingly, seven types of geometries are supported.
-The following section demonstrates creating a `shapely` geometry of each type, using a `string` in the WKT format as input.
-First, we need to import the `shapely.wkt` module:
+The following section demonstrates creating a `shapely` geometry of each type, from scratch or using a `string` in the WKT format as input. To do so , we need to import the `shapely.wkt` module and geometry types:
 
 ```{python}
 import shapely.wkt as wkt
+from shapely.geometry import Point
+```
+
+Creating a point object is as simple as:
+
+```{python}
+point = Point(5,2)
+point
 ```
 
 Then, we use the `wkt.loads` (stands for "load a WKT *s*tring") to transform a WKT string to a `shapely` geometry object. 
@@ -186,11 +193,23 @@ point
 Here is an example of a `MULTIPOINT` geometry:
 
 ```{python}
+from shapely.geometry import MultiPoint
+multipoint = MultiPoint([(5,2), (1,3), (3,4), (3,2)])
+multipoint
+```
+
+```{python}
 multipoint = wkt.loads("MULTIPOINT ((5 2), (1 3), (3 4), (3 2))")
 multipoint
 ```
 
 Here is an example of a `LINESTRING` geometry:
+
+```{python}
+from shapely.geometry import LineString
+linestring = LineString([(1,5), (4,4), (4,1), (2,2), (3,2)])
+linestring
+```
 
 ```{python}
 linestring = wkt.loads("LINESTRING (1 5, 4 4, 4 1, 2 2, 3 2)")
@@ -200,11 +219,23 @@ linestring
 Here is an example of a `MULTILINESTRING` geometry:
 
 ```{python}
+from shapely.geometry import MultiLineString
+linestring = MultiLineString([[(1,5), (4,4), (4,1), (2,2), (3,2)], [(1,2), (2,4)]])
+linestring
+```
+
+```{python}
 multilinestring = wkt.loads("MULTILINESTRING ((1 5, 4 4, 4 1, 2 2, 3 2), (1 2, 2 4))")
 multilinestring
 ```
 
 Here is an example of a `POLYGON` geometry:
+
+```{python}
+from shapely.geometry import Polygon
+linestring = Polygon([(1,5), (2,2), (4,1), (4,4), (1,5)], [[(2,4), (3,4), (3,3), (2,3), (2,4)]])
+linestring
+```
 
 ```{python}
 polygon = wkt.loads("POLYGON ((1 5, 2 2, 4 1, 4 4, 1 5), (2 4, 3 4, 3 3, 2 3, 2 4))")
@@ -214,11 +245,25 @@ polygon
 Here is an example of a `MULTIPOLYGON` geometry:
 
 ```{python}
+from shapely.geometry import MultiPolygon
+multipolygon = MultiPolygon([Polygon([(1,5), (2,2), (4,1), (4,4), (1,5)]), 
+                             Polygon([(0,2), (1,2), (1,3), (0,3), (0,2)])])
+multipolygon
+```
+
+```{python}
 multipolygon = wkt.loads("MULTIPOLYGON (((1 5, 2 2, 4 1, 4 4, 1 5)), ((0 2, 1 2, 1 3, 0 3, 0 2)))")
 multipolygon
 ```
 
 And, finally, here is an example of a `GEOMETRYCOLLECTION` geometry:
+
+```{python}
+from shapely.geometry import GeometryCollection
+multipoint = GeometryCollection([MultiPoint([(5,2), (1,3), (3,4), (3,2)]),
+                                 MultiLineString([[(1,5), (4,4), (4,1), (2,2), (3,2)], [(1,2), (2,4)]])])
+multipoint
+```
 
 ```{python}
 geometrycollection = wkt.loads("GEOMETRYCOLLECTION (MULTIPOINT (5 2, 1 3, 3 4, 3 2), LINESTRING (1 5, 4 4, 4 1, 2 2, 3 2))")
@@ -383,7 +428,7 @@ x["tem"].plot(col="time", col_wrap=4)
 ## Coordinate Reference Systems
 
 ```{python}
-dat.crs
+gdf.crs
 ```
 
 ```{python}

--- a/code/chapters/02-spatial-data.py
+++ b/code/chapters/02-spatial-data.py
@@ -77,85 +77,90 @@ else:
   z = zipfile.ZipFile(io.BytesIO(r.content))
   z.extractall(".")
 
-dat = gpd.read_file("data/world.gpkg")
+gdf = gpd.read_file("data/world.gpkg")
 
 # The result is a `GeoDataFrame`:
 
-type(dat)
+type(gdf)
 
 # The `GeoDataFrame` class is an extension of the `DataFrame` class. 
 # Thus, we can treat a vector layer as a table and process it using the ordinary, i.e., non-spatial, **pandas** methods.
 # For example, the following expression creates a subset with just the country name and the geometry (see below):
 
-dat = dat[["name_long", "geometry"]]
-dat
+gdf = gdf[["name_long", "geometry"]]
+gdf
 
 # The following expression creates a subset based on a condition, including just `"Egypt"`:
 
-dat[dat["name_long"] == "Egypt"]
+gdf[gdf["name_long"] == "Egypt"]
 
 # Finally, to get a sense of the spatial component of the vector layer, it can be plotted using the `.plot` method, as follows:
 
-dat.plot()
+gdf.plot()
 
 # or using `.hvplot` to get an interactive plot:
 
 # +
 # import hvplot.pandas
-# dat.hvplot(title='Hello world', geo=True, hover_cols=['name_long'], legend=False).opts(bgcolor='lightgray', active_tools=['wheel_zoom']) 
+# gdf.hvplot(title='Hello world', geo=True, hover_cols=['name_long'], legend=False).opts(bgcolor='lightgray', active_tools=['wheel_zoom']) 
 # -
 
 # This way, we can also add background tiles:
 
 # +
-# dat.hvplot(tiles='OSM', alpha=0.5, geo=True, title='Hello world', hover_cols=['name_long'], legend=False).opts(active_tools=['wheel_zoom']) 
+# gdf.hvplot(tiles='OSM', alpha=0.5, geo=True, title='Hello world', hover_cols=['name_long'], legend=False).opts(active_tools=['wheel_zoom']) 
 # -
 
 # ### Geometry columns
 #
 # One of the columns in a `GeoDataFrame` is a geometry column, of class `GeoSeries`.
-# The geometry column contains the geometric part of the vector layer, e.g., the `POLYGON` or `MULTIPOLYGON` geometries of the 177 countries in `dat`:
+# The geometry column contains the geometric part of the vector layer, e.g., the `POLYGON` or `MULTIPOLYGON` geometries of the 177 countries in `gdf`:
 
-dat["geometry"]
+gdf["geometry"]
 
 # The geometry column also contains the spatial reference information, if any (see below).
 #
 # Many of the spatial operators, such as calculating the centroid, buffer, or bounding box of each feature, in fact involve just the geometry. 
 # Therefore, for example, the following expressions give exactly the same result, a `GeoSeries` with country bounding boxes:
 
-dat.bounds
+gdf.bounds
 
-dat["geometry"].bounds
+gdf["geometry"].bounds
 
 # Another useful property of the geometry column is the geometry type (see below). 
 # Note that the types of geometries contained in a geometry column (and, thus, a vector layer) are not necessarily the same.
 # Accordingly, the `.type` property returns a `Series` (of type `string`), rather than a single value:
 
-dat["geometry"].type
+gdf["geometry"].type
 
 # To summarize the occurrence of different geometry types in a geometry column, we can use the **pandas** method called `value_counts`:
 
-dat["geometry"].type.value_counts()
+gdf["geometry"].type.value_counts()
 
-# In this case, we see that the `dat` layer contains `Polygon` and `MultiPolygon` geometries.
+# In this case, we see that the `gdf` layer contains `Polygon` and `MultiPolygon` geometries.
 #
 # ### Geometries
 #
 # Each element in the geometry column is a geometry object, of class `shapely`.
 # For example, here is one specific geometry selected by implicit index (that of Canada):
 
-dat["geometry"].iloc[3]
+gdf["geometry"].iloc[3]
 
 # and here is a specific geometry selected based on the `"name_long"` attribute:
 
-dat[dat["name_long"] == "Egypt"]["geometry"].iloc[0]
+gdf[gdf["name_long"] == "Egypt"]["geometry"].iloc[0]
 
 # The **shapely** package is compatible with the Simple Features standard.
 # Accordingly, seven types of geometries are supported.
-# The following section demonstrates creating a `shapely` geometry of each type, using a `string` in the WKT format as input.
-# First, we need to import the `shapely.wkt` module:
+# The following section demonstrates creating a `shapely` geometry of each type, from scratch or using a `string` in the WKT format as input. To do so , we need to import the `shapely.wkt` module and geometry types:
 
 import shapely.wkt as wkt
+from shapely.geometry import Point
+
+# Creating a point object is as simple as:
+
+point = Point(5,2)
+point
 
 # Then, we use the `wkt.loads` (stands for "load a WKT *s*tring") to transform a WKT string to a `shapely` geometry object. 
 # Here is an example of a `POINT` geometry:
@@ -165,30 +170,56 @@ point
 
 # Here is an example of a `MULTIPOINT` geometry:
 
+from shapely.geometry import MultiPoint
+multipoint = MultiPoint([(5,2), (1,3), (3,4), (3,2)])
+multipoint
+
 multipoint = wkt.loads("MULTIPOINT ((5 2), (1 3), (3 4), (3 2))")
 multipoint
 
 # Here is an example of a `LINESTRING` geometry:
+
+from shapely.geometry import LineString
+linestring = LineString([(1,5), (4,4), (4,1), (2,2), (3,2)])
+linestring
 
 linestring = wkt.loads("LINESTRING (1 5, 4 4, 4 1, 2 2, 3 2)")
 linestring
 
 # Here is an example of a `MULTILINESTRING` geometry:
 
+from shapely.geometry import MultiLineString
+linestring = MultiLineString([[(1,5), (4,4), (4,1), (2,2), (3,2)], [(1,2), (2,4)]])
+linestring
+
 multilinestring = wkt.loads("MULTILINESTRING ((1 5, 4 4, 4 1, 2 2, 3 2), (1 2, 2 4))")
 multilinestring
 
 # Here is an example of a `POLYGON` geometry:
+
+from shapely.geometry import Polygon
+linestring = Polygon([(1,5), (2,2), (4,1), (4,4), (1,5)], [[(2,4), (3,4), (3,3), (2,3), (2,4)]])
+linestring
 
 polygon = wkt.loads("POLYGON ((1 5, 2 2, 4 1, 4 4, 1 5), (2 4, 3 4, 3 3, 2 3, 2 4))")
 polygon
 
 # Here is an example of a `MULTIPOLYGON` geometry:
 
+from shapely.geometry import MultiPolygon
+multipolygon = MultiPolygon([Polygon([(1,5), (2,2), (4,1), (4,4), (1,5)]), 
+                             Polygon([(0,2), (1,2), (1,3), (0,3), (0,2)])])
+multipolygon
+
 multipolygon = wkt.loads("MULTIPOLYGON (((1 5, 2 2, 4 1, 4 4, 1 5)), ((0 2, 1 2, 1 3, 0 3, 0 2)))")
 multipolygon
 
 # And, finally, here is an example of a `GEOMETRYCOLLECTION` geometry:
+
+from shapely.geometry import GeometryCollection
+multipoint = GeometryCollection([MultiPoint([(5,2), (1,3), (3,4), (3,2)]),
+                                 MultiLineString([[(1,5), (4,4), (4,1), (2,2), (3,2)], [(1,2), (2,4)]])])
+multipoint
 
 geometrycollection = wkt.loads("GEOMETRYCOLLECTION (MULTIPOINT (5 2, 1 3, 3 4, 3 2), LINESTRING (1 5, 4 4, 4 1, 2 2, 3 2))")
 geometrycollection
@@ -324,7 +355,7 @@ x["tem"].plot(col="time", col_wrap=4)
 
 # ## Coordinate Reference Systems
 
-dat.crs
+gdf.crs
 
 src.crs
 

--- a/ipynb/02-spatial-data.ipynb
+++ b/ipynb/02-spatial-data.ipynb
@@ -105,7 +105,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "dat = gpd.read_file(\"data/world.gpkg\")"
+        "gdf = gpd.read_file(\"data/world.gpkg\")"
       ],
       "execution_count": null,
       "outputs": []
@@ -121,7 +121,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "type(dat)"
+        "type(gdf)"
       ],
       "execution_count": null,
       "outputs": []
@@ -139,8 +139,8 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "dat = dat[[\"name_long\", \"geometry\"]]\n",
-        "dat"
+        "gdf = gdf[[\"name_long\", \"geometry\"]]\n",
+        "gdf"
       ],
       "execution_count": null,
       "outputs": []
@@ -156,7 +156,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "dat[dat[\"name_long\"] == \"Egypt\"]"
+        "gdf[gdf[\"name_long\"] == \"Egypt\"]"
       ],
       "execution_count": null,
       "outputs": []
@@ -172,7 +172,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "dat.plot()"
+        "gdf.plot()"
       ],
       "execution_count": null,
       "outputs": []
@@ -189,7 +189,7 @@
       "metadata": {},
       "source": [
         "# import hvplot.pandas\n",
-        "# dat.hvplot(title='Hello world', geo=True, hover_cols=['name_long'], legend=False).opts(bgcolor='lightgray', active_tools=['wheel_zoom']) "
+        "# gdf.hvplot(title='Hello world', geo=True, hover_cols=['name_long'], legend=False).opts(bgcolor='lightgray', active_tools=['wheel_zoom']) "
       ],
       "execution_count": null,
       "outputs": []
@@ -205,7 +205,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "# dat.hvplot(tiles='OSM', alpha=0.5, geo=True, title='Hello world', hover_cols=['name_long'], legend=False).opts(active_tools=['wheel_zoom']) "
+        "# gdf.hvplot(tiles='OSM', alpha=0.5, geo=True, title='Hello world', hover_cols=['name_long'], legend=False).opts(active_tools=['wheel_zoom']) "
       ],
       "execution_count": null,
       "outputs": []
@@ -217,14 +217,14 @@
         "### Geometry columns\n",
         "\n",
         "One of the columns in a `GeoDataFrame` is a geometry column, of class `GeoSeries`.\n",
-        "The geometry column contains the geometric part of the vector layer, e.g., the `POLYGON` or `MULTIPOLYGON` geometries of the 177 countries in `dat`:"
+        "The geometry column contains the geometric part of the vector layer, e.g., the `POLYGON` or `MULTIPOLYGON` geometries of the 177 countries in `gdf`:"
       ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "dat[\"geometry\"]"
+        "gdf[\"geometry\"]"
       ],
       "execution_count": null,
       "outputs": []
@@ -243,7 +243,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "dat.bounds"
+        "gdf.bounds"
       ],
       "execution_count": null,
       "outputs": []
@@ -252,7 +252,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "dat[\"geometry\"].bounds"
+        "gdf[\"geometry\"].bounds"
       ],
       "execution_count": null,
       "outputs": []
@@ -270,7 +270,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "dat[\"geometry\"].type"
+        "gdf[\"geometry\"].type"
       ],
       "execution_count": null,
       "outputs": []
@@ -286,7 +286,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "dat[\"geometry\"].type.value_counts()"
+        "gdf[\"geometry\"].type.value_counts()"
       ],
       "execution_count": null,
       "outputs": []
@@ -295,7 +295,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "In this case, we see that the `dat` layer contains `Polygon` and `MultiPolygon` geometries.\n",
+        "In this case, we see that the `gdf` layer contains `Polygon` and `MultiPolygon` geometries.\n",
         "\n",
         "### Geometries\n",
         "\n",
@@ -307,7 +307,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "dat[\"geometry\"].iloc[3]"
+        "gdf[\"geometry\"].iloc[3]"
       ],
       "execution_count": null,
       "outputs": []
@@ -323,7 +323,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "dat[dat[\"name_long\"] == \"Egypt\"][\"geometry\"].iloc[0]"
+        "gdf[gdf[\"name_long\"] == \"Egypt\"][\"geometry\"].iloc[0]"
       ],
       "execution_count": null,
       "outputs": []
@@ -334,15 +334,32 @@
       "source": [
         "The **shapely** package is compatible with the Simple Features standard.\n",
         "Accordingly, seven types of geometries are supported.\n",
-        "The following section demonstrates creating a `shapely` geometry of each type, using a `string` in the WKT format as input.\n",
-        "First, we need to import the `shapely.wkt` module:"
+        "The following section demonstrates creating a `shapely` geometry of each type, from scratch or using a `string` in the WKT format as input. To do so , we need to import the `shapely.wkt` module and geometry types:"
       ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "import shapely.wkt as wkt"
+        "import shapely.wkt as wkt\n",
+        "from shapely.geometry import Point"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Creating a point object is as simple as:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "point = Point(5,2)\n",
+        "point"
       ],
       "execution_count": null,
       "outputs": []
@@ -376,6 +393,17 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
+        "from shapely.geometry import MultiPoint\n",
+        "multipoint = MultiPoint([(5,2), (1,3), (3,4), (3,2)])\n",
+        "multipoint"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
         "multipoint = wkt.loads(\"MULTIPOINT ((5 2), (1 3), (3 4), (3 2))\")\n",
         "multipoint"
       ],
@@ -388,6 +416,17 @@
       "source": [
         "Here is an example of a `LINESTRING` geometry:"
       ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from shapely.geometry import LineString\n",
+        "linestring = LineString([(1,5), (4,4), (4,1), (2,2), (3,2)])\n",
+        "linestring"
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -410,6 +449,17 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
+        "from shapely.geometry import MultiLineString\n",
+        "linestring = MultiLineString([[(1,5), (4,4), (4,1), (2,2), (3,2)], [(1,2), (2,4)]])\n",
+        "linestring"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
         "multilinestring = wkt.loads(\"MULTILINESTRING ((1 5, 4 4, 4 1, 2 2, 3 2), (1 2, 2 4))\")\n",
         "multilinestring"
       ],
@@ -422,6 +472,17 @@
       "source": [
         "Here is an example of a `POLYGON` geometry:"
       ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from shapely.geometry import Polygon\n",
+        "linestring = Polygon([(1,5), (2,2), (4,1), (4,4), (1,5)], [[(2,4), (3,4), (3,3), (2,3), (2,4)]])\n",
+        "linestring"
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -444,6 +505,18 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
+        "from shapely.geometry import MultiPolygon\n",
+        "multipolygon = MultiPolygon([Polygon([(1,5), (2,2), (4,1), (4,4), (1,5)]), \n",
+        "                             Polygon([(0,2), (1,2), (1,3), (0,3), (0,2)])])\n",
+        "multipolygon"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
         "multipolygon = wkt.loads(\"MULTIPOLYGON (((1 5, 2 2, 4 1, 4 4, 1 5)), ((0 2, 1 2, 1 3, 0 3, 0 2)))\")\n",
         "multipolygon"
       ],
@@ -456,6 +529,18 @@
       "source": [
         "And, finally, here is an example of a `GEOMETRYCOLLECTION` geometry:"
       ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from shapely.geometry import GeometryCollection\n",
+        "multipoint = GeometryCollection([MultiPoint([(5,2), (1,3), (3,4), (3,2)]),\n",
+        "                                 MultiLineString([[(1,5), (4,4), (4,1), (2,2), (3,2)], [(1,2), (2,4)]])])\n",
+        "multipoint"
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -757,7 +842,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "dat.crs"
+        "gdf.crs"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
I'm adding examples of how to create shapely geometries from scratch in a pythonic way because I don't think it would be good to leave the impression that the WKT string path would be the recommended way to create geometry objects.

I also renamed dat to gdf because (g)df is the standard GeoDataFrame name in GeoPandas examples. 